### PR TITLE
Generate sitemap.xml and robots.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ bun bun-react-ssg build --url https://example.com
 
 If `--url` is omitted, sitemap generation is skipped and a warning is printed.
 
+When a sitemap is generated, a `robots.txt` file is also created in the same `dist` directory that includes a `Sitemap:` directive pointing to the generated sitemap.
+
 ## Generated Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A _super_ lightweight static site generator that probably shouldn't be used in p
 - [x] Dynamic route generation with `[param]` syntax
 - [x] Meta tags and SEO support
 - [x] Tailwind CSS support
-- [ ] Auto generating sitemap.xml
+- [x] Auto generating sitemap.xml
 
 ## Dynamic Routes
 
@@ -76,6 +76,16 @@ To build the site into a dist directory for production, run:
 ```bash
 bun run build
 ```
+
+### Sitemap generation
+
+Provide a base site URL to generate `sitemap.xml` during build:
+
+```bash
+bun bun-react-ssg build --url https://example.com
+```
+
+If `--url` is omitted, sitemap generation is skipped and a warning is printed.
 
 ## Generated Structure
 

--- a/bun-react-ssg/bin/cli.ts
+++ b/bun-react-ssg/bin/cli.ts
@@ -26,7 +26,7 @@ const args = process.argv.slice(2)
 const command = args[0]
 
 function readFlag(name: string, fallback?: string) {
-  const idx = args.findIndex((a: string) => a === name)
+  const idx = args.findIndex((a) => a === name)
   if (idx !== -1 && args[idx + 1]) return args[idx + 1]
   return fallback
 }
@@ -62,7 +62,7 @@ async function main() {
       const watcher = watch(
         absolutePagesDir,
         { recursive: true },
-        async (eventType: any, filename: any) => {
+        async (eventType, filename) => {
           if (
             isBuilding ||
             !filename ||
@@ -106,7 +106,7 @@ async function main() {
     const distPath = resolve(distDir)
     serve({
       port,
-      async fetch(request: any) {
+      async fetch(request) {
         const url = new URL(request.url)
         const pathname = url.pathname
 

--- a/bun-react-ssg/bin/cli.ts
+++ b/bun-react-ssg/bin/cli.ts
@@ -16,6 +16,7 @@ Options:
   --pages <dir>	Path to pages directory (default: src/pages)
   --dist <dir>	Path to output directory (default: dist)
   --port <port>	Port for serve (default: 3000)
+  --url <url>	Base site URL for sitemap (e.g., https://example.com)
   --watch	Watch for changes and rebuild (build command only)
   -h, --help	Show help
 `)
@@ -25,7 +26,7 @@ const args = process.argv.slice(2)
 const command = args[0]
 
 function readFlag(name: string, fallback?: string) {
-  const idx = args.findIndex((a) => a === name)
+  const idx = args.findIndex((a: string) => a === name)
   if (idx !== -1 && args[idx + 1]) return args[idx + 1]
   return fallback
 }
@@ -42,6 +43,7 @@ async function main() {
 
   const pagesDir = readFlag('--pages', 'src/pages')!
   const distDir = readFlag('--dist', 'dist')!
+  const url = readFlag('--url')
 
   if (command === 'build') {
     const watchMode = hasFlag('--watch')
@@ -50,7 +52,7 @@ async function main() {
       console.log('🔄 Watch mode enabled. Building and watching for changes...')
 
       // Initial build
-      await buildSite({ pagesDir, distDir })
+      await buildSite({ pagesDir, distDir, url })
 
       // Watch for changes
       const absolutePagesDir = resolve(pagesDir)
@@ -60,7 +62,7 @@ async function main() {
       const watcher = watch(
         absolutePagesDir,
         { recursive: true },
-        async (eventType, filename) => {
+        async (eventType: any, filename: any) => {
           if (
             isBuilding ||
             !filename ||
@@ -73,7 +75,7 @@ async function main() {
           isBuilding = true
           console.log(`\n📁 File changed: ${filename}, rebuilding...`)
           try {
-            await buildSite({ pagesDir, distDir })
+            await buildSite({ pagesDir, distDir, url })
             console.log('✅ Rebuild complete!')
           } catch (error) {
             console.error('❌ Build failed:', error)
@@ -93,7 +95,7 @@ async function main() {
       // Keep alive
       await new Promise(() => {})
     } else {
-      await buildSite({ pagesDir, distDir })
+      await buildSite({ pagesDir, distDir, url })
     }
     return
   }
@@ -104,7 +106,7 @@ async function main() {
     const distPath = resolve(distDir)
     serve({
       port,
-      async fetch(request) {
+      async fetch(request: any) {
         const url = new URL(request.url)
         const pathname = url.pathname
 

--- a/bun-react-ssg/src/index.tsx
+++ b/bun-react-ssg/src/index.tsx
@@ -49,6 +49,8 @@ export async function buildSite({
     try {
       await generateSitemap(absoluteDistDir, routes, url)
       console.log(`Generated sitemap.xml with ${routes.length} entries`)
+      await generateRobots(absoluteDistDir, url)
+      console.log('Generated robots.txt linking to sitemap.xml')
     } catch (error) {
       console.warn('Warning: Failed to generate sitemap.xml:', error)
     }
@@ -245,6 +247,12 @@ async function generateSitemap(
   const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join('\n')}\n</urlset>\n`
 
   await write(join(distDirAbs, 'sitemap.xml'), xml)
+}
+
+async function generateRobots(distDirAbs: string, baseUrl: string) {
+  const normalizedBase = normalizeBaseUrl(baseUrl)
+  const content = `User-agent: *\nAllow: /\nSitemap: ${normalizedBase}/sitemap.xml\n`
+  await write(join(distDirAbs, 'robots.txt'), content)
 }
 
 export type { Metadata } from './html'

--- a/bun-react-ssg/src/index.tsx
+++ b/bun-react-ssg/src/index.tsx
@@ -10,6 +10,7 @@ import type { GenerateStaticParamsResult } from './types'
 export type BuildSiteOptions = {
   pagesDir: string // e.g., 'src/pages'
   distDir?: string // e.g., 'dist'
+  url?: string // Base site URL for sitemap generation (e.g., https://example.com)
 }
 
 type RouteInfo = {
@@ -24,6 +25,7 @@ type RouteInfo = {
 export async function buildSite({
   pagesDir,
   distDir = 'dist',
+  url,
 }: BuildSiteOptions) {
   const startTime = Date.now()
 
@@ -40,6 +42,18 @@ export async function buildSite({
 
   for (const route of routes) {
     await generateRoute(route, absolutePagesDir, absoluteDistDir)
+  }
+
+  // Generate sitemap.xml if a base URL is provided
+  if (url && typeof url === 'string' && url.trim().length > 0) {
+    try {
+      await generateSitemap(absoluteDistDir, routes, url)
+      console.log(`Generated sitemap.xml with ${routes.length} entries`)
+    } catch (error) {
+      console.warn('Warning: Failed to generate sitemap.xml:', error)
+    }
+  } else {
+    console.warn('Skipping sitemap.xml generation: --url not provided')
   }
 
   const duration = Date.now() - startTime
@@ -201,6 +215,36 @@ async function generateRoute(
   const document = createHtml({ html, metadata })
 
   await write(filePath, document)
+}
+
+function normalizeBaseUrl(baseUrl: string) {
+  return baseUrl.replace(/\/+$/, '')
+}
+
+function outputFileToPath(outputFile: string) {
+  if (outputFile.endsWith('index.html')) {
+    const dir = outputFile.slice(0, -'index.html'.length)
+    return '/' + dir
+  }
+  // Fallback: ensure leading slash
+  return '/' + outputFile
+}
+
+async function generateSitemap(
+  distDirAbs: string,
+  routes: RouteInfo[],
+  baseUrl: string
+) {
+  const normalizedBase = normalizeBaseUrl(baseUrl)
+  const urls = routes.map((r) => {
+    const path = outputFileToPath(r.outputFile)
+    const loc = path === '/' ? `${normalizedBase}/` : `${normalizedBase}${path}`
+    return `  <url>\n    <loc>${loc}</loc>\n  </url>`
+  })
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join('\n')}\n</urlset>\n`
+
+  await write(join(distDirAbs, 'sitemap.xml'), xml)
 }
 
 export type { Metadata } from './html'

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun-react-ssg build --watch",
-    "build": "bun-react-ssg build && bun run css:build",
+    "build": "bun-react-ssg build --url https://bun-react-ssg.pages.dev && bun run css:build",
     "css:build": "tailwindcss -i ./src/style.css -o ./dist/style.css",
     "css:watch": "tailwindcss -i ./src/style.css -o ./dist/style.css --watch",
     "serve": "bun-react-ssg serve"


### PR DESCRIPTION
Add automatic sitemap generation at build time to improve SEO, controlled by a new `--url` CLI option.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5573cce-9733-41d2-9be2-fea58e5aa069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5573cce-9733-41d2-9be2-fea58e5aa069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `--url` flag to build that generates `sitemap.xml` (and `robots.txt`) and wire it through CLI, core build, docs, and example site.
> 
> - **Core (`bun-react-ssg/src/index.tsx`)**
>   - Extend `BuildSiteOptions` with `url`; when provided, generate `sitemap.xml` and `robots.txt` in `dist/`.
>   - Add helpers `normalizeBaseUrl`, `outputFileToPath`, and generation functions `generateSitemap`, `generateRobots`; log success/warnings.
> - **CLI (`bun-react-ssg/bin/cli.ts`)**
>   - Add `--url <url>` option and pass it to `buildSite` for initial, watch, and standard builds.
> - **Docs (`README.md`)**
>   - Mark sitemap as complete and add a "Sitemap generation" section with `--url` usage and note about `robots.txt`.
> - **Example site (`site/package.json`)**
>   - Update `build` script to include `--url https://bun-react-ssg.pages.dev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d414e2c46a18a7f78bcff424058d36f34fe3b02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->